### PR TITLE
Fix the reduce-variables branch

### DIFF
--- a/src/app/calculation.cpp
+++ b/src/app/calculation.cpp
@@ -211,7 +211,9 @@ void Calculation::doCalculationsFor(AbimoInputRecord& inputRecord)
     }
 
     Precipitation precipitation = getPrecipitation(
-        static_cast<float>(inputRecord.precipitationYear), m_initValues
+        inputRecord.precipitationYear,
+        inputRecord.precipitationSummer,
+        m_initValues
     );
 
     PotentialEvaporation potentialEvaporation = getPotentialEvaporation(
@@ -449,14 +451,27 @@ PotentialEvaporation Calculation::getPotentialEvaporation(
 }
 
 Precipitation Calculation::getPrecipitation(
-    int precipitationYear, InitValues& initValues
+    int precipitationYear,
+    int precipitationSummer,
+    InitValues& initValues
 )
 {
     Precipitation result;
 
-    // precipitation (at ground level)
+    // Set integer fields (originally from input dbf)
+    result.perYearInteger = precipitationYear;
+    result.inSummerInteger = precipitationSummer;
+
+    // Set float fields
+
+    // Correct the (non-summer) precipitation (at ground level)
     result.perYearCorrectedFloat = static_cast<float>(
         precipitationYear * initValues.getPrecipitationCorrectionFactor()
+    );
+
+    // No correction for summer precipitation!
+    result.inSummerFloat = static_cast<float>(
+        precipitationSummer
     );
 
     return result;

--- a/src/app/calculation.cpp
+++ b/src/app/calculation.cpp
@@ -498,8 +498,6 @@ float Calculation::realEvapotranspiration(
         m_resultRecord.usage == Usage::forested_W,
         m_resultRecord.yieldPower,
         m_resultRecord.irrigation,
-        //static_cast<float>(precipitation.inSummerInteger),
-        //static_cast<float>(inputRecord.precipitationSummer),
         precipitation.inSummerFloat,
         potentialEvaporation.inSummerInteger,
         m_resultRecord.meanPotentialCapillaryRiseRate

--- a/src/app/calculation.cpp
+++ b/src/app/calculation.cpp
@@ -485,6 +485,11 @@ float Calculation::realEvapotranspiration(
 {
     assert(potentialEvaporation.perYearFloat > 0.0);
 
+    assert(
+        precipitation.inSummerInteger ==
+        inputRecord.precipitationSummer
+    );
+
     // Determine effectivity/effectiveness ??? parameter (old???: bag) for
     // unsealed surfaces
     // Modul Raster abgespeckt (???)
@@ -493,7 +498,9 @@ float Calculation::realEvapotranspiration(
         m_resultRecord.usage == Usage::forested_W,
         m_resultRecord.yieldPower,
         m_resultRecord.irrigation,
-        static_cast<float>(precipitation.inSummerInteger),
+        //static_cast<float>(precipitation.inSummerInteger),
+        //static_cast<float>(inputRecord.precipitationSummer),
+        precipitation.inSummerFloat,
         potentialEvaporation.inSummerInteger,
         m_resultRecord.meanPotentialCapillaryRiseRate
     );

--- a/src/app/calculation.h
+++ b/src/app/calculation.h
@@ -89,7 +89,9 @@ private:
     );
 
     Precipitation getPrecipitation(
-        int precipitationYear, InitValues& initValues
+        int precipitationYear,
+        int precipitationSummer,
+        InitValues& initValues
     );
 
     float realEvapotranspiration(

--- a/src/app/pdr.h
+++ b/src/app/pdr.h
@@ -56,6 +56,7 @@ struct Precipitation {
     int inSummerInteger;
 
     float perYearCorrectedFloat;
+    float inSummerFloat;
 };
 
 class PDR


### PR DESCRIPTION
These changes, finally make the `reduce-variables` branch pass the tests. The new struct `Precipitation` was not yet containing what could be expected!